### PR TITLE
New test

### DIFF
--- a/examples/slow_stream_demo.py
+++ b/examples/slow_stream_demo.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""
+Slow streaming demo to show real-time end time updates in GTKWave
+"""
+
+import subprocess
+import time
+import math
+from vcd.writer import VCDWriter
+import threading
+import sys
+
+def slow_stream_with_updates():
+    """Stream data slowly to see end time updates"""
+    shmidcat_proc = None
+    gtkwave_proc = None
+
+    try:
+        print("Starting shmidcat process...")
+        shmidcat_proc = subprocess.Popen(
+            ['builddir/src/helpers/shmidcat'],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            text=True,
+            bufsize=1
+        )
+
+        print("Starting GTKWave in interactive mode...")
+        gtkwave_proc = subprocess.Popen(
+            ['xvfb-run', '-a', 'builddir/src/gtkwave', '-I', '-v'],
+            stdin=shmidcat_proc.stdout,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            bufsize=1
+        )
+
+        print("Creating VCD writer...")
+        writer = VCDWriter(shmidcat_proc.stdin, timescale='1 ns', date='today')
+        sine_var = writer.register_var('test', 'sine_wave', 'integer', size=8, init=0)
+
+        print("Priming pipeline with VCD header...")
+        writer.flush()
+
+        # Give GTKWave time to start
+        time.sleep(2)
+
+        print("Starting slow streaming (1 timestep per second)...")
+        print("=" * 50)
+
+        amplitude = 127
+        steps = 30  # Stream 30 steps slowly
+
+        # Thread to capture GTKWave stdout
+        def capture_stdout():
+            while True:
+                line = gtkwave_proc.stdout.readline()
+                if not line:
+                    break
+                print(f"GTKWave STDOUT: {line.strip()}")
+
+        # Thread to capture GTKWave stderr
+        def capture_stderr():
+            while True:
+                line = gtkwave_proc.stderr.readline()
+                if not line:
+                    break
+                print(f"GTKWave STDERR: {line.strip()}")
+
+        stdout_thread = threading.Thread(target=capture_stdout, daemon=True)
+        stderr_thread = threading.Thread(target=capture_stderr, daemon=True)
+        stdout_thread.start()
+        stderr_thread.start()
+
+        # Stream data slowly
+        for timestamp in range(steps):
+            angle = (timestamp / 5.0) * 2 * math.pi
+            value = int(amplitude * math.sin(angle))
+            writer.change(sine_var, timestamp, value)
+            writer.flush()
+
+            print(f"Sent timestamp {timestamp+1}/{steps} (value: {value})")
+            time.sleep(1)  # Slow down to 1 second per timestep
+
+        print("\nFinished streaming. Keeping GTKWave open for 5 more seconds...")
+        time.sleep(5)
+
+        print("Demo completed successfully!")
+
+    except Exception as e:
+        print(f"Error: {e}")
+    finally:
+        print("Cleaning up...")
+        if 'writer' in locals():
+            writer.close()
+        if gtkwave_proc:
+            gtkwave_proc.terminate()
+        if shmidcat_proc:
+            shmidcat_proc.terminate()
+
+if __name__ == "__main__":
+    slow_stream_with_updates()

--- a/lib/libgtkwave/src/gw-vcd-loader.c
+++ b/lib/libgtkwave/src/gw-vcd-loader.c
@@ -1699,7 +1699,13 @@ static void vcd_parse_string(GwVcdLoader *self)
         GwTime tim;
         GwTime *tt;
 
+        // Debug: print the time string being parsed
+        g_printerr("DEBUG: Parsing time string: '%s'\n", self->yytext);
+
         tim = atoi_64(self->yytext + 1);
+
+        // Debug: print the parsed time value
+        g_printerr("DEBUG: Parsed time value: %ld\n", tim);
 
         if (self->start_time < 0) {
             self->start_time = tim;
@@ -1801,11 +1807,6 @@ void vcd_parse(GwVcdLoader *self, GError **error)
                     // Otherwise, continue parsing time/value data
                 }
                 break;
-                
-            case T_TIME:
-                // Debug: print time value being parsed
-                g_printerr("DEBUG: Parsing time value: %s\n", self->yytext);
-                // Fall through to default handling
 
             case T_STRING:
                 vcd_parse_string(self);

--- a/lib/libgtkwave/src/gw-vcd-loader.c
+++ b/lib/libgtkwave/src/gw-vcd-loader.c
@@ -1699,13 +1699,7 @@ static void vcd_parse_string(GwVcdLoader *self)
         GwTime tim;
         GwTime *tt;
 
-        // Debug: print the time string being parsed
-        g_printerr("DEBUG: Parsing time string: '%s'\n", self->yytext);
-
         tim = atoi_64(self->yytext + 1);
-
-        // Debug: print the parsed time value
-        g_printerr("DEBUG: Parsed time value: %ld\n", tim);
 
         if (self->start_time < 0) {
             self->start_time = tim;

--- a/lib/libgtkwave/src/gw-vcd-partial-loader.c
+++ b/lib/libgtkwave/src/gw-vcd-partial-loader.c
@@ -105,6 +105,7 @@ static int vcd_partial_getch_fetch(GwVcdLoader *loader)
 {
     GwVcdPartialLoader *self = GW_VCD_PARTIAL_LOADER(loader->getch_fetch_override_data);
     size_t rd = 0;
+    gboolean data_processed = FALSE;
 
     if (!self->shm_data) {
         g_printerr("No shared memory data available\n");
@@ -114,14 +115,12 @@ static int vcd_partial_getch_fetch(GwVcdLoader *loader)
     // Check if a block is ready in the SHM ring buffer
     guint8 block_status = get_8(self->shm_data, self->consume_offset);
     
-    g_printerr("DEBUG: getch_fetch called, block_status: %u, consume_offset: %ld\n",
-               block_status, self->consume_offset);
-    
     if (block_status != 0) {
         rd = get_32(self->shm_data, self->consume_offset + 1);
-        g_printerr("DEBUG: Block ready, rd: %zu\n", rd);
 
         if (rd > 0) {
+            data_processed = TRUE;
+            
             // Copy data from SHM into the VCD loader's internal buffer
             for (size_t i = 0; i < rd; i++) {
                 guint8 byte = get_8(self->shm_data, self->consume_offset + 5 + i);
@@ -138,6 +137,7 @@ static int vcd_partial_getch_fetch(GwVcdLoader *loader)
                 self->consume_offset %= RING_BUFFER_SIZE;
             }
             
+            g_printerr("DEBUG: Block ready, rd: %zu\n", rd);
             g_printerr("DEBUG: Copied %zu bytes to buffer: %s\n", rd, loader->vcdbuf);
         }
     }
@@ -145,10 +145,12 @@ static int vcd_partial_getch_fetch(GwVcdLoader *loader)
     loader->vend = (loader->vst = loader->vcdbuf) + rd;
 
     if (!rd) {
-        g_printerr("DEBUG: No data available, returning -1\n");
         return -1; // EOF for this kick
     }
-    g_printerr("DEBUG: Returning first byte: %d ('%c')\n", (int)(*loader->vst), *loader->vst);
+    
+    if (data_processed) {
+        g_printerr("DEBUG: Returning first byte: %d ('%c')\n", (int)(*loader->vst), *loader->vst);
+    }
     return (int)(*loader->vst);
 }
 
@@ -168,20 +170,26 @@ void gw_vcd_partial_loader_kick(GwVcdPartialLoader *self)
     // Actively call the parent's parser. It will use our override.
     GError *error = NULL;
     
-    // Debug: Print times before parsing
-    g_printerr("DEBUG: Before parse - start: %ld, end: %ld, current: %ld\n",
-               loader->start_time, loader->end_time, loader->current_time);
+    // Store initial time to detect if new data is processed
+    GwTime initial_time = loader->current_time;
     
     vcd_parse(loader, &error);
-    
-    // Debug: Print times after parsing
-    g_printerr("DEBUG: After parse - start: %ld, end: %ld, current: %ld\n",
-               loader->start_time, loader->end_time, loader->current_time);
 
-    // After parsing, update the loader's time range
-    if (loader->current_time > loader->end_time) {
-        loader->end_time = loader->current_time;
-        g_printerr("DEBUG: Updated end_time to: %ld\n", loader->end_time);
+    // Check if new data was processed (time advanced)
+    gboolean data_processed = (loader->current_time > initial_time);
+    
+    // Only print debug messages if new data was processed
+    if (data_processed) {
+        g_printerr("DEBUG: Before parse - start: %ld, end: %ld, current: %ld\n",
+                   loader->start_time, loader->end_time, initial_time);
+        g_printerr("DEBUG: After parse - start: %ld, end: %ld, current: %ld\n",
+                   loader->start_time, loader->end_time, loader->current_time);
+
+        // After parsing, update the loader's time range
+        if (loader->current_time > loader->end_time) {
+            loader->end_time = loader->current_time;
+            g_printerr("DEBUG: Updated end_time to: %ld\n", loader->end_time);
+        }
     }
 
     loader->getch_fetch_override = NULL; // Unhook until next kick
@@ -302,10 +310,6 @@ void gw_vcd_partial_loader_update_time_range(GwVcdPartialLoader *self, GwDumpFil
     
     GwVcdLoader *loader = GW_VCD_LOADER(self);
     
-    // Debug: Print loader time values
-    g_printerr("DEBUG: Loader times - start: %ld, end: %ld, current: %ld\n",
-               loader->start_time, loader->end_time, loader->current_time);
-    
     // Only update if we have valid time data
     if (loader->start_time >= 0 && loader->end_time >= loader->start_time) {
         // Update internal time range directly (time-range property is construct-only)
@@ -324,9 +328,5 @@ void gw_vcd_partial_loader_update_time_range(GwVcdPartialLoader *self, GwDumpFil
             tr->end = loader->end_time;
 
         }
-        g_printerr("DEBUG: Time range updated to start: %ld, end: %ld\n",
-                   loader->start_time, loader->end_time);
-    } else {
-        g_printerr("DEBUG: Time range not updated - invalid time data\n");
     }
 }

--- a/lib/libgtkwave/src/gw-vcd-partial-loader.c
+++ b/lib/libgtkwave/src/gw-vcd-partial-loader.c
@@ -111,69 +111,11 @@ static int vcd_partial_getch_fetch(GwVcdLoader *loader)
         return -1;
     }
 
-    // Scan for the next available block in the ring buffer
-    gssize scan_offset = self->consume_offset;
-    guint8 block_status = get_8(self->shm_data, scan_offset);
+    // Check if a block is ready in the SHM ring buffer
+    guint8 block_status = get_8(self->shm_data, self->consume_offset);
     
-    g_printerr("DEBUG: getch_fetch called, scan_offset: %ld, block_status: %u, shm_data: %p\n",
-               scan_offset, block_status, self->shm_data);
-
-    // If current block is consumed (status 0), scan for next available block
-    if (block_status == 0) {
-        g_printerr("DEBUG: Scanning for next available block...\n");
-
-        // Scan for the next available block, but limit the scan to avoid infinite loops
-        gssize current_offset = scan_offset;
-        gssize bytes_scanned = 0;
-        gboolean found_block = FALSE;
-
-        // Scan at most the entire buffer size to prevent infinite loops
-        while (bytes_scanned < RING_BUFFER_SIZE) {
-            // Read the length of the current block
-            guint32 block_length = get_32(self->shm_data, current_offset + 1);
-
-            // If block_length is 0, this might be an invalid block or end of data
-            // Use a minimum skip to avoid infinite loops
-            if (block_length == 0) {
-                // Skip status + 4-byte length
-                current_offset += 5;
-                bytes_scanned += 5;
-            } else {
-                // Move to the next block
-                current_offset += 1 + 4 + block_length;
-                bytes_scanned += 1 + 4 + block_length;
-            }
-
-            // Handle ring buffer wrap-around
-            if (current_offset >= RING_BUFFER_SIZE) {
-                current_offset %= RING_BUFFER_SIZE;
-            }
-
-            // Check the status of the next block
-            block_status = get_8(self->shm_data, current_offset);
-
-            if (block_status != 0) {
-                found_block = TRUE;
-                break;
-            }
-
-            // If we've wrapped around to the starting point, stop scanning
-            if (current_offset == scan_offset) {
-                g_printerr("DEBUG: Wrapped around to starting offset, no available blocks\n");
-                break;
-            }
-        }
-
-        if (found_block) {
-            // Found an available block, update consume_offset
-            self->consume_offset = current_offset;
-            g_printerr("DEBUG: Found available block at offset %ld\n", self->consume_offset);
-        } else {
-            g_printerr("DEBUG: No available blocks found after scanning %ld bytes\n", bytes_scanned);
-            loader->vend = (loader->vst = loader->vcdbuf) + 0;
-            return -1;
-        }
-    }
+    g_printerr("DEBUG: getch_fetch called, block_status: %u, consume_offset: %ld\n",
+               block_status, self->consume_offset);
     
     if (block_status != 0) {
         rd = get_32(self->shm_data, self->consume_offset + 1);
@@ -216,6 +158,7 @@ void gw_vcd_partial_loader_kick(GwVcdPartialLoader *self)
     if (!self->shm_data) return;
 
     GwVcdLoader *loader = GW_VCD_LOADER(self);
+    loader->vst = loader->vend = loader->vcdbuf;
     
     // Store self as user data for the callback
     loader->getch_fetch_override_data = self;
@@ -359,9 +302,9 @@ void gw_vcd_partial_loader_update_time_range(GwVcdPartialLoader *self, GwDumpFil
     
     GwVcdLoader *loader = GW_VCD_LOADER(self);
     
-    // Debug: Print loader time values and consume offset
-    g_printerr("DEBUG: Loader times - start: %ld, end: %ld, current: %ld, consume_offset: %ld\n",
-               loader->start_time, loader->end_time, loader->current_time, self->consume_offset);
+    // Debug: Print loader time values
+    g_printerr("DEBUG: Loader times - start: %ld, end: %ld, current: %ld\n",
+               loader->start_time, loader->end_time, loader->current_time);
     
     // Only update if we have valid time data
     if (loader->start_time >= 0 && loader->end_time >= loader->start_time) {

--- a/lib/libgtkwave/test/meson.build
+++ b/lib/libgtkwave/test/meson.build
@@ -129,3 +129,17 @@ foreach test : dumpfile_tests
         args: ['-u', golden_file, dump_target],
     )
 endforeach
+
+test_gw_slow_stream_exe = executable(
+    'test-gw-slow-stream',
+    ['test-gw-slow-stream.c', 'test-util.c'],
+    dependencies: libgtkwave_dep,
+)
+
+test(
+    'test-gw-slow-stream',
+    test_gw_slow_stream_exe,
+    workdir: meson.current_source_dir(),
+    protocol: 'tap',
+    env: test_env,
+)

--- a/lib/libgtkwave/test/test-gw-slow-stream.c
+++ b/lib/libgtkwave/test/test-gw-slow-stream.c
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2024 GTKWave Contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT of OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#include <glib.h>
+#include <glib/gstdio.h>
+#include <unistd.h>
+#include <signal.h>
+#include <sys/wait.h>
+#include "gw-vcd-partial-loader.h"
+#include "gw-dump-file.h"
+#include "gw-facs.h"
+#include "gw-time-range.h"
+
+static const gchar *vcd_data[] = {
+    "$date today $end\n",
+    "$timescale 1 ns $end\n",
+    "$scope module test $end\n",
+    "$var integer 8 ! sine_wave $end\n",
+    "$upscope $end\n",
+    "$enddefinitions $end\n",
+    "#0\n",
+    "b0 !\n",
+    "#1\n",
+    "b10000000 !\n",
+    "#2\n",
+    "b11111111 !\n",
+    "#3\n",
+    "b0 !\n",
+    NULL
+};
+
+static void test_slow_stream(void)
+{
+    g_printerr("--- test_slow_stream: starting ---\n");
+    const gchar *build_dir = g_getenv("MESON_BUILD_ROOT");
+    gchar *shmidcat_path = g_build_filename(build_dir, "src", "helpers", "shmidcat", NULL);
+
+    gchar *shm_id_str = NULL;
+    gint child_stdin_fd, child_stdout_fd;
+    GPid shmidcat_pid;
+    GError *error = NULL;
+
+    gchar *cmd[] = { shmidcat_path, NULL };
+    gboolean success = g_spawn_async_with_pipes(
+        NULL, cmd, NULL,
+        G_SPAWN_SEARCH_PATH | G_SPAWN_DO_NOT_REAP_CHILD,
+        NULL, NULL, &shmidcat_pid,
+        &child_stdin_fd, &child_stdout_fd, NULL, &error
+    );
+    g_assert_no_error(error);
+    g_assert_true(success);
+
+    GIOChannel *out_ch = g_io_channel_unix_new(child_stdout_fd);
+    g_io_channel_read_line(out_ch, &shm_id_str, NULL, NULL, NULL);
+    g_assert_nonnull(shm_id_str);
+    shm_id_str[strcspn(shm_id_str, "\r\n")] = 0;
+
+    g_usleep(100000);
+
+    GIOChannel *in_channel = g_io_channel_unix_new(child_stdin_fd);
+    g_io_channel_set_encoding(in_channel, NULL, NULL);
+    g_io_channel_set_buffered(in_channel, FALSE);
+
+    // Feed header
+    for (int i = 0; i < 6; i++) {
+        g_io_channel_write_chars(in_channel, vcd_data[i], -1, NULL, NULL);
+    }
+    g_io_channel_flush(in_channel, NULL);
+    g_usleep(200000);
+
+    GwVcdPartialLoader *loader = gw_vcd_partial_loader_new();
+    GError *load_error = NULL;
+    GwDumpFile *dump_file = gw_vcd_partial_loader_load(loader, shm_id_str, &load_error);
+    g_assert_no_error(load_error);
+    g_assert_nonnull(dump_file);
+
+    GwTimeRange *time_range = gw_dump_file_get_time_range(dump_file);
+    GwTime current_end_time = gw_time_range_get_end(time_range);
+    g_assert_cmpint(current_end_time, ==, 0);
+
+    // Feed data line by line
+    for (int i = 6; vcd_data[i] != NULL; i++) {
+        g_printerr("--- test_slow_stream: loop iteration %d ---\n", i);
+        g_io_channel_write_chars(in_channel, vcd_data[i], -1, NULL, NULL);
+        g_io_channel_flush(in_channel, NULL);
+        g_usleep(100000);
+
+        gw_vcd_partial_loader_kick(loader);
+        gw_vcd_partial_loader_update_time_range(loader, dump_file);
+
+        time_range = gw_dump_file_get_time_range(dump_file);
+        current_end_time = gw_time_range_get_end(time_range);
+
+        if (vcd_data[i][0] == '#') {
+            gint64 expected_time = g_ascii_strtoll(vcd_data[i] + 1, NULL, 10);
+            g_assert_cmpint(current_end_time, ==, expected_time);
+        }
+    }
+
+    close(child_stdin_fd);
+
+    g_object_unref(dump_file);
+    gw_vcd_partial_loader_cleanup(loader);
+    g_object_unref(loader);
+    g_free(shm_id_str);
+
+    int status;
+    waitpid(shmidcat_pid, &status, 0);
+    g_spawn_close_pid(shmidcat_pid);
+
+    g_free(shmidcat_path);
+    g_printerr("--- test_slow_stream: finished ---\n");
+}
+
+int main(int argc, char **argv)
+{
+    g_test_init(&argc, &argv, NULL);
+    g_test_add_func("/VcdPartialLoader/SlowStream", test_slow_stream);
+    return g_test_run();
+}

--- a/lib/libgtkwave/test/test-gw-slow-stream.c
+++ b/lib/libgtkwave/test/test-gw-slow-stream.c
@@ -24,7 +24,11 @@
 #include <glib/gstdio.h>
 #include <unistd.h>
 #include <signal.h>
+#if defined(_WIN32) || defined(__MINGW32__)
+#include <windows.h>
+#else
 #include <sys/wait.h>
+#endif
 #include "gw-vcd-partial-loader.h"
 #include "gw-dump-file.h"
 #include "gw-facs.h"
@@ -50,7 +54,7 @@ static const gchar *vcd_data[] = {
 
 static void test_slow_stream(void)
 {
-    g_printerr("--- test_slow_stream: starting ---\n");
+
     const gchar *build_dir = g_getenv("MESON_BUILD_ROOT");
     gchar *shmidcat_path = g_build_filename(build_dir, "src", "helpers", "shmidcat", NULL);
 
@@ -99,7 +103,7 @@ static void test_slow_stream(void)
 
     // Feed data line by line
     for (int i = 6; vcd_data[i] != NULL; i++) {
-        g_printerr("--- test_slow_stream: loop iteration %d ---\n", i);
+
         g_io_channel_write_chars(in_channel, vcd_data[i], -1, NULL, NULL);
         g_io_channel_flush(in_channel, NULL);
         g_usleep(100000);
@@ -123,12 +127,16 @@ static void test_slow_stream(void)
     g_object_unref(loader);
     g_free(shm_id_str);
 
+#if defined(_WIN32) || defined(__MINGW32__)
+    WaitForSingleObject(shmidcat_pid, INFINITE);
+#else
     int status;
     waitpid(shmidcat_pid, &status, 0);
+#endif
     g_spawn_close_pid(shmidcat_pid);
 
     g_free(shmidcat_path);
-    g_printerr("--- test_slow_stream: finished ---\n");
+
 }
 
 int main(int argc, char **argv)

--- a/lib/libgtkwave/test/test-gw-vcd-partial-loader.c
+++ b/lib/libgtkwave/test/test-gw-vcd-partial-loader.c
@@ -24,7 +24,11 @@
 #include <glib/gstdio.h>
 #include <unistd.h>
 #include <signal.h>
+#if defined(_WIN32) || defined(__MINGW32__)
+#include <windows.h>
+#else
 #include <sys/wait.h>
+#endif
 #include "gw-vcd-partial-loader.h"
 #include "gw-dump-file.h"
 #include "gw-facs.h"
@@ -148,8 +152,12 @@ static void test_incremental_loading(void)
     g_free(shm_id_str);
 
     // Wait for shmidcat to exit
+#if defined(_WIN32) || defined(__MINGW32__)
+    WaitForSingleObject(shmidcat_pid, INFINITE);
+#else
     int status;
     waitpid(shmidcat_pid, &status, 0);
+#endif
     g_spawn_close_pid(shmidcat_pid);
 
     g_free(shmidcat_path);

--- a/src/vcd_partial_adapter.c
+++ b/src/vcd_partial_adapter.c
@@ -30,6 +30,13 @@ static gboolean kick_timeout_callback(gpointer user_data)
     // Update time range which will set the new end time
     gw_vcd_partial_loader_update_time_range(the_loader, GLOBALS->dump_file);
 
+    if (GLOBALS->dump_file) {
+        GwTimeRange *time_range = gw_dump_file_get_time_range(GLOBALS->dump_file);
+        if (time_range) {
+            GLOBALS->tims.last = gw_time_range_get_end(time_range);
+        }
+    }
+
     // Debug: Check dump file time range
     if (GLOBALS->dump_file) {
         GwTimeRange *time_range = gw_dump_file_get_time_range(GLOBALS->dump_file);

--- a/src/vcd_partial_adapter.c
+++ b/src/vcd_partial_adapter.c
@@ -37,25 +37,28 @@ static gboolean kick_timeout_callback(gpointer user_data)
         }
     }
 
-    // Debug: Check dump file time range
-    if (GLOBALS->dump_file) {
-        GwTimeRange *time_range = gw_dump_file_get_time_range(GLOBALS->dump_file);
-        if (time_range) {
-            GwTime start = gw_time_range_get_start(time_range);
-            GwTime end = gw_time_range_get_end(time_range);
-            fprintf(stderr, "DEBUG: Dump file time range - start: %ld, end: %ld\n", start, end);
-        }
-    }
-
-    // Debug: Check what the time range update did to global tims
-    fprintf(stderr, "DEBUG: Global tims - last: %ld, first: %ld\n",
-            GLOBALS->tims.last, GLOBALS->tims.first);
 
     // Check if new data was processed (time advanced)
     gboolean data_processed = (GLOBALS->tims.last > initial_time);
-    fprintf(stderr, "DEBUG: Time check - initial: %ld, current: %ld, processed: %d\n",
-            initial_time, GLOBALS->tims.last, data_processed);
+    
     if (data_processed) {
+        // Debug: Check dump file time range
+        if (GLOBALS->dump_file) {
+            GwTimeRange *time_range = gw_dump_file_get_time_range(GLOBALS->dump_file);
+            if (time_range) {
+                GwTime start = gw_time_range_get_start(time_range);
+                GwTime end = gw_time_range_get_end(time_range);
+                fprintf(stderr, "DEBUG: Dump file time range - start: %ld, end: %ld\n", start, end);
+            }
+        }
+
+        // Debug: Check what the time range update did to global tims
+        fprintf(stderr, "DEBUG: Global tims - last: %ld, first: %ld\n",
+                GLOBALS->tims.last, GLOBALS->tims.first);
+
+        fprintf(stderr, "DEBUG: Time check - initial: %ld, current: %ld, processed: %d\n",
+                initial_time, GLOBALS->tims.last, data_processed);
+        
         last_processed_time = GLOBALS->tims.last;
         fprintf(stderr, "DEBUG: Kicking partial loader (new data processed)\n");
         
@@ -102,8 +105,6 @@ static gboolean kick_timeout_callback(gpointer user_data)
     }
 
     if (data_processed) {
-        fprintf(stderr, "DEBUG: Kicking partial loader (new data processed)\n");
-        
         // Update the dump file's time range with any newly discovered times.
         gw_vcd_partial_loader_update_time_range(the_loader, GLOBALS->dump_file);
 


### PR DESCRIPTION
This pull request introduces a new slow streaming demo for GTKWave, adds a dedicated test for slow streaming in the VCD partial loader, and improves the handling and updating of end times during partial VCD loading. The changes also clean up debug output and ensure proper initialization of internal buffers. The most important changes are grouped below:

**New Features and Demos:**

* Added a new example script `slow_stream_demo.py` to demonstrate real-time end time updates in GTKWave with slow VCD streaming. This script streams VCD data slowly to GTKWave and captures its output for easier debugging.

* Introduced a new C test `test-gw-slow-stream.c` and integrated it into the Meson build system to verify that the partial VCD loader correctly updates the end time as new data arrives. [[1]](diffhunk://#diff-212d781e4462c506dd0da752013a74be19abf65c3f18ddaecbfe6f419de5105aR1-R139) [[2]](diffhunk://#diff-859a9e9dffcf90f46a773e61a11455c4cdf16d5f7bedfe24fef0b5586ab0a013R132-R145)

**Improvements to Partial VCD Loading and End Time Updates:**

* In `gw-vcd-partial-loader.c`, the internal VCD buffer pointers (`vst`, `vend`) are now explicitly reset before each partial load, ensuring correct incremental parsing of streamed VCD data.

* In `vcd_partial_adapter.c`, the code now updates the global last time (`GLOBALS->tims.last`) with the current end time from the dump file after each partial loader kick, improving synchronization of the displayed end time in the UI.

**Code Cleanups:**

* Removed a debug print statement for parsed time values in `gw-vcd-loader.c` to reduce unnecessary log output.

## Summary by Sourcery

Add a slow streaming demo and test for GTKWave, improve partial VCD loader buffer handling and end time updates, and clean up debug output.

New Features:
- Add slow_stream_demo.py example to demonstrate real-time end time updates in GTKWave with slow VCD streaming

Enhancements:
- Reset internal VCD loader buffer pointers before each partial load for correct incremental parsing
- Update GLOBALS->tims.last from the dump file end time after each partial load kick to synchronize the displayed end time
- Remove unnecessary debug print from gw-vcd-loader to reduce log noise

Tests:
- Introduce test-gw-slow-stream.c and integrate it into the Meson build to verify incremental end time updates in the partial VCD loader