### PR TITLE
Fix real-time VCD end time updates in interactive mode.

### DIFF
--- a/examples/slow_stream_demo.py
+++ b/examples/slow_stream_demo.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""
+Slow streaming demo to show real-time end time updates in GTKWave
+"""
+
+import subprocess
+import time
+import math
+from vcd.writer import VCDWriter
+import threading
+import sys
+
+def slow_stream_with_updates():
+    """Stream data slowly to see end time updates"""
+    shmidcat_proc = None
+    gtkwave_proc = None
+
+    try:
+        print("Starting shmidcat process...")
+        shmidcat_proc = subprocess.Popen(
+            ['builddir/src/helpers/shmidcat'],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            text=True,
+            bufsize=1
+        )
+
+        print("Starting GTKWave in interactive mode...")
+        gtkwave_proc = subprocess.Popen(
+            ['xvfb-run', '-a', 'builddir/src/gtkwave', '-I', '-v'],
+            stdin=shmidcat_proc.stdout,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            bufsize=1
+        )
+
+        print("Creating VCD writer...")
+        writer = VCDWriter(shmidcat_proc.stdin, timescale='1 ns', date='today')
+        sine_var = writer.register_var('test', 'sine_wave', 'integer', size=8, init=0)
+
+        print("Priming pipeline with VCD header...")
+        writer.flush()
+
+        # Give GTKWave time to start
+        time.sleep(2)
+
+        print("Starting slow streaming (1 timestep per second)...")
+        print("=" * 50)
+
+        amplitude = 127
+        steps = 30  # Stream 30 steps slowly
+
+        # Thread to capture GTKWave stdout
+        def capture_stdout():
+            while True:
+                line = gtkwave_proc.stdout.readline()
+                if not line:
+                    break
+                print(f"GTKWave STDOUT: {line.strip()}")
+
+        # Thread to capture GTKWave stderr
+        def capture_stderr():
+            while True:
+                line = gtkwave_proc.stderr.readline()
+                if not line:
+                    break
+                print(f"GTKWave STDERR: {line.strip()}")
+
+        stdout_thread = threading.Thread(target=capture_stdout, daemon=True)
+        stderr_thread = threading.Thread(target=capture_stderr, daemon=True)
+        stdout_thread.start()
+        stderr_thread.start()
+
+        # Stream data slowly
+        for timestamp in range(steps):
+            angle = (timestamp / 5.0) * 2 * math.pi
+            value = int(amplitude * math.sin(angle))
+            writer.change(sine_var, timestamp, value)
+            writer.flush()
+
+            print(f"Sent timestamp {timestamp+1}/{steps} (value: {value})")
+            time.sleep(1)  # Slow down to 1 second per timestep
+
+        print("\nFinished streaming. Keeping GTKWave open for 5 more seconds...")
+        time.sleep(5)
+
+        print("Demo completed successfully!")
+
+    except Exception as e:
+        print(f"Error: {e}")
+    finally:
+        print("Cleaning up...")
+        if 'writer' in locals():
+            writer.close()
+        if gtkwave_proc:
+            gtkwave_proc.terminate()
+        if shmidcat_proc:
+            shmidcat_proc.terminate()
+
+if __name__ == "__main__":
+    slow_stream_with_updates()

--- a/lib/libgtkwave/src/gw-vcd-loader.c
+++ b/lib/libgtkwave/src/gw-vcd-loader.c
@@ -1801,11 +1801,6 @@ void vcd_parse(GwVcdLoader *self, GError **error)
                     // Otherwise, continue parsing time/value data
                 }
                 break;
-                
-            case T_TIME:
-                // Debug: print time value being parsed
-                g_printerr("DEBUG: Parsing time value: %s\n", self->yytext);
-                // Fall through to default handling
 
             case T_STRING:
                 vcd_parse_string(self);

--- a/lib/libgtkwave/src/gw-vcd-partial-loader.c
+++ b/lib/libgtkwave/src/gw-vcd-partial-loader.c
@@ -158,6 +158,7 @@ void gw_vcd_partial_loader_kick(GwVcdPartialLoader *self)
     if (!self->shm_data) return;
 
     GwVcdLoader *loader = GW_VCD_LOADER(self);
+    loader->vst = loader->vend = loader->vcdbuf;
     
     // Store self as user data for the callback
     loader->getch_fetch_override_data = self;

--- a/lib/libgtkwave/test/meson.build
+++ b/lib/libgtkwave/test/meson.build
@@ -129,3 +129,17 @@ foreach test : dumpfile_tests
         args: ['-u', golden_file, dump_target],
     )
 endforeach
+
+test_gw_slow_stream_exe = executable(
+    'test-gw-slow-stream',
+    ['test-gw-slow-stream.c', 'test-util.c'],
+    dependencies: libgtkwave_dep,
+)
+
+test(
+    'test-gw-slow-stream',
+    test_gw_slow_stream_exe,
+    workdir: meson.current_source_dir(),
+    protocol: 'tap',
+    env: test_env,
+)

--- a/lib/libgtkwave/test/test-gw-slow-stream.c
+++ b/lib/libgtkwave/test/test-gw-slow-stream.c
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2024 GTKWave Contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT of OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#include <glib.h>
+#include <glib/gstdio.h>
+#include <unistd.h>
+#include <signal.h>
+#include <sys/wait.h>
+#include "gw-vcd-partial-loader.h"
+#include "gw-dump-file.h"
+#include "gw-facs.h"
+#include "gw-time-range.h"
+
+static const gchar *vcd_data[] = {
+    "$date today $end\n",
+    "$timescale 1 ns $end\n",
+    "$scope module test $end\n",
+    "$var integer 8 ! sine_wave $end\n",
+    "$upscope $end\n",
+    "$enddefinitions $end\n",
+    "#0\n",
+    "b0 !\n",
+    "#1\n",
+    "b10000000 !\n",
+    "#2\n",
+    "b11111111 !\n",
+    "#3\n",
+    "b0 !\n",
+    NULL
+};
+
+static void test_slow_stream(void)
+{
+    const gchar *build_dir = g_getenv("MESON_BUILD_ROOT");
+    gchar *shmidcat_path = g_build_filename(build_dir, "src", "helpers", "shmidcat", NULL);
+
+    gchar *shm_id_str = NULL;
+    gint child_stdin_fd, child_stdout_fd;
+    GPid shmidcat_pid;
+    GError *error = NULL;
+
+    gchar *cmd[] = { shmidcat_path, NULL };
+    gboolean success = g_spawn_async_with_pipes(
+        NULL, cmd, NULL,
+        G_SPAWN_SEARCH_PATH | G_SPAWN_DO_NOT_REAP_CHILD,
+        NULL, NULL, &shmidcat_pid,
+        &child_stdin_fd, &child_stdout_fd, NULL, &error
+    );
+    g_assert_no_error(error);
+    g_assert_true(success);
+
+    GIOChannel *out_ch = g_io_channel_unix_new(child_stdout_fd);
+    g_io_channel_read_line(out_ch, &shm_id_str, NULL, NULL, NULL);
+    g_assert_nonnull(shm_id_str);
+    shm_id_str[strcspn(shm_id_str, "\r\n")] = 0;
+
+    g_usleep(100000);
+
+    GIOChannel *in_channel = g_io_channel_unix_new(child_stdin_fd);
+    g_io_channel_set_encoding(in_channel, NULL, NULL);
+    g_io_channel_set_buffered(in_channel, FALSE);
+
+    // Feed header
+    for (int i = 0; i < 6; i++) {
+        g_io_channel_write_chars(in_channel, vcd_data[i], -1, NULL, NULL);
+    }
+    g_io_channel_flush(in_channel, NULL);
+    g_usleep(200000);
+
+    GwVcdPartialLoader *loader = gw_vcd_partial_loader_new();
+    GError *load_error = NULL;
+    GwDumpFile *dump_file = gw_vcd_partial_loader_load(loader, shm_id_str, &load_error);
+    g_assert_no_error(load_error);
+    g_assert_nonnull(dump_file);
+
+    GwTimeRange *time_range = gw_dump_file_get_time_range(dump_file);
+    GwTime current_end_time = gw_time_range_get_end(time_range);
+    g_assert_cmpint(current_end_time, ==, 0);
+
+    // Feed data line by line
+    for (int i = 6; vcd_data[i] != NULL; i++) {
+        g_io_channel_write_chars(in_channel, vcd_data[i], -1, NULL, NULL);
+        g_io_channel_flush(in_channel, NULL);
+        g_usleep(100000);
+
+        gw_vcd_partial_loader_kick(loader);
+        gw_vcd_partial_loader_update_time_range(loader, dump_file);
+
+        time_range = gw_dump_file_get_time_range(dump_file);
+        current_end_time = gw_time_range_get_end(time_range);
+
+        if (vcd_data[i][0] == '#') {
+            gint64 expected_time = g_ascii_strtoll(vcd_data[i] + 1, NULL, 10);
+            g_assert_cmpint(current_end_time, ==, expected_time);
+        }
+    }
+
+    close(child_stdin_fd);
+
+    g_object_unref(dump_file);
+    gw_vcd_partial_loader_cleanup(loader);
+    g_object_unref(loader);
+    g_free(shm_id_str);
+
+    int status;
+    waitpid(shmidcat_pid, &status, 0);
+    g_spawn_close_pid(shmidcat_pid);
+
+    g_free(shmidcat_path);
+}
+
+int main(int argc, char **argv)
+{
+    g_test_init(&argc, &argv, NULL);
+    g_test_add_func("/VcdPartialLoader/SlowStream", test_slow_stream);
+    return g_test_run();
+}

--- a/src/vcd_partial_adapter.c
+++ b/src/vcd_partial_adapter.c
@@ -30,6 +30,13 @@ static gboolean kick_timeout_callback(gpointer user_data)
     // Update time range which will set the new end time
     gw_vcd_partial_loader_update_time_range(the_loader, GLOBALS->dump_file);
 
+    if (GLOBALS->dump_file) {
+        GwTimeRange *time_range = gw_dump_file_get_time_range(GLOBALS->dump_file);
+        if (time_range) {
+            GLOBALS->tims.last = gw_time_range_get_end(time_range);
+        }
+    }
+
     // Debug: Check dump file time range
     if (GLOBALS->dump_file) {
         GwTimeRange *time_range = gw_dump_file_get_time_range(GLOBALS->dump_file);


### PR DESCRIPTION
When streaming VCD data slowly to GTKWave using `shmidcat`, the end time of the simulation was not being updated in real-time. This was because the VCD loader's internal buffer was not being reset after each "kick", causing the loader to miss new data.

This commit fixes the issue by resetting the VCD buffer in the `gw_vcd_partial_loader_kick` function. This ensures that the loader always reads the latest data from the shared memory buffer.

A new unit test, `test-gw-slow-stream`, has been added to reproduce the bug and verify the fix.