### PR TITLE
Fix interactive deadlock and add logging

### DIFF
--- a/lib/libgtkwave/src/gw-vcd-loader.c
+++ b/lib/libgtkwave/src/gw-vcd-loader.c
@@ -1791,15 +1791,6 @@ void vcd_parse(GwVcdLoader *self, GError **error)
 
             case T_ENDDEFINITIONS:
                 vcd_parse_enddefinitions(self, error);
-                // In partial loading mode, stop parsing after header only for initial load
-                if (self->getch_fetch_override != NULL) {
-                    // Check if we can access the partial loader to see if header was already parsed
-                    // For now, use a simple workaround: if current_time is not -1, we've already parsed header
-                    if (self->current_time == -1) {
-                        return; // Initial header parsing, stop here
-                    }
-                    // Otherwise, continue parsing time/value data
-                }
                 break;
 
             case T_STRING:

--- a/src/vcd_partial_adapter.c
+++ b/src/vcd_partial_adapter.c
@@ -77,6 +77,12 @@ static gboolean kick_timeout_callback(gpointer user_data)
             }
             fprintf(stdout, "INFO: Total traces: %d\n", trace_count);
 
+/* 
+ * Value string mapping for h_val encoding.
+ * If the encoding changes, update this definition to keep value mapping consistent.
+ */
+static const char GW_HVAL_VALUE_STR[] = "0xz11xz0xxxxxxxx";
+
             GwTrace *first_trace = GLOBALS->traces.first;
             if (first_trace && !first_trace->vector) {
                 GwHistEnt *last_he = &(first_trace->n.nd->head);
@@ -84,8 +90,7 @@ static gboolean kick_timeout_callback(gpointer user_data)
                     last_he = last_he->next;
                 }
                 if (last_he) {
-                    const char *value_str = "0xz11xz0xxxxxxxx";
-                    char last_val = value_str[last_he->v.h_val & 0xF];
+                    char last_val = GW_HVAL_VALUE_STR[last_he->v.h_val & 0xF];
                     fprintf(stdout, "INFO: First trace ('%s') summary: last value = %c at time %"PRId64"\n",
                             first_trace->name, last_val, last_he->time);
                 }


### PR DESCRIPTION
This pull request focuses on improving the user-facing logging and cleaning up the code by removing internal debug statements from `src/vcd_partial_adapter.c`. The changes make runtime information more accessible to users while reducing noise from low-level debug logs, resulting in clearer output and easier troubleshooting.

User-facing logging improvements:

* Added user-friendly informational messages to indicate when new VCD data has been processed, including the new end time and a summary of traces and their last values. This helps users understand the current state of the VCD session without needing to interpret debug logs.

Code cleanup and simplification:

* Removed numerous internal `DEBUG` log statements throughout the file, including those in `vcd_partial_main`, `vcd_partial_cleanup`, and timer setup/cleanup code, to reduce log clutter and make logs more relevant to end users. [[1]](diffhunk://#diff-45ae1f25b52677b97fb88d83ac26231eab7aef32868ec2b303759ed84b1e2c59L184-L205) [[2]](diffhunk://#diff-45ae1f25b52677b97fb88d83ac26231eab7aef32868ec2b303759ed84b1e2c59R210-L228) [[3]](diffhunk://#diff-45ae1f25b52677b97fb88d83ac26231eab7aef32868ec2b303759ed84b1e2c59L237-L250)
* Eliminated the unused `last_processed_time` variable, as it was no longer necessary after the logging refactor.

## Summary by Sourcery

Improve the interactive VCD adapter by adding user-friendly logging for processed data, removing noisy debug statements, and cleaning up session initialization and cleanup to avoid deadlocks.

New Features:
- Add INFO logs for new VCD data processing including new end time, total traces count, and first trace value summary

Bug Fixes:
- Prevent interactive session deadlock by reordering cleanup and mutex locking in vcd_partial_main

Enhancements:
- Remove internal DEBUG log statements throughout the adapter and eliminate the unused last_processed_time variable for cleaner user-focused output