### PR TITLE
fix(vcd): Correct partial loader exit condition

### DIFF
--- a/lib/libgtkwave/src/gw-vcd-loader.c
+++ b/lib/libgtkwave/src/gw-vcd-loader.c
@@ -1791,15 +1791,6 @@ void vcd_parse(GwVcdLoader *self, GError **error)
 
             case T_ENDDEFINITIONS:
                 vcd_parse_enddefinitions(self, error);
-                // In partial loading mode, stop parsing after header only for initial load
-                if (self->getch_fetch_override != NULL) {
-                    // Check if we can access the partial loader to see if header was already parsed
-                    // For now, use a simple workaround: if current_time is not -1, we've already parsed header
-                    if (self->current_time == -1) {
-                        return; // Initial header parsing, stop here
-                    }
-                    // Otherwise, continue parsing time/value data
-                }
                 break;
 
             case T_STRING:


### PR DESCRIPTION
The VCD partial loader would exit prematurely after parsing the header. The condition to check if the header had already been parsed was faulty, relying on `current_time == -1`, which was not a reliable indicator of the initial parse state.

This caused the parser to exit after the `$enddefinitions` token on every kick, preventing any subsequent waveform data from being processed in interactive mode.

This fix removes the unnecessary and buggy conditional return, allowing the parser to correctly process all data provided in each kick.