### PR TITLE
Fix interactive loading (ADD SIGNALS AUTOMATICALLY)

### DIFF
--- a/examples/slow_stream_demo.py
+++ b/examples/slow_stream_demo.py
@@ -18,7 +18,7 @@ def slow_stream_with_updates():
     try:
         print("Starting shmidcat process...")
         shmidcat_proc = subprocess.Popen(
-            ['build/src/helpers/shmidcat'],
+            ['builddir/src/helpers/shmidcat'],
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             text=True,
@@ -27,7 +27,7 @@ def slow_stream_with_updates():
 
         print("Starting GTKWave in interactive mode...")
         gtkwave_proc = subprocess.Popen(
-            ['xvfb-run', '-a', 'build/src/gtkwave', '-I', '-v'],
+            ['xvfb-run', '-a', 'builddir/src/gtkwave', '-I', '-v'],
             stdin=shmidcat_proc.stdout,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,

--- a/lib/libgtkwave/src/gw-vcd-file-private.h
+++ b/lib/libgtkwave/src/gw-vcd-file-private.h
@@ -4,6 +4,7 @@ struct _GwVcdFile
 {
     GwDumpFile parent_instance;
 
+    gboolean partial_load;
     gboolean preserve_glitches;
     gboolean preserve_glitches_real;
 

--- a/lib/libgtkwave/src/gw-vcd-file.c
+++ b/lib/libgtkwave/src/gw-vcd-file.c
@@ -381,6 +381,12 @@ static void gw_vcd_file_import_trace(GwVcdFile *self, GwNode *np)
     guint32 len = 1;
     guint32 vlist_type;
 
+    if (self->partial_load && np->mv.mvlfac_vlist_writer != NULL) {
+        np->mv.mvlfac_vlist = gw_vlist_writer_finish(np->mv.mvlfac_vlist_writer);
+        /* g_object_unref(np->mv.mvlfac_vlist_writer); */
+        np->mv.mvlfac_vlist_writer = NULL;
+    }
+
     if (np->mv.mvlfac_vlist == NULL) {
         return;
     }

--- a/lib/libgtkwave/src/gw-vcd-partial-loader.c
+++ b/lib/libgtkwave/src/gw-vcd-partial-loader.c
@@ -304,6 +304,7 @@ GwDumpFile *gw_vcd_partial_loader_load(GwVcdPartialLoader *self, const gchar *sh
         "time-range", initial_time_range,
         NULL
     );
+    GW_VCD_FILE(dump_file)->partial_load = TRUE;
     g_object_unref(initial_time_range);
 
     // Clean up intermediate objects (they are now owned by the dump_file)

--- a/src/analyzer.c
+++ b/src/analyzer.c
@@ -1398,6 +1398,26 @@ unsigned IsShadowed(GwTrace *t)
     return 0;
 }
 
+void analyzer_import_all_signals(void)
+{
+    if (!GLOBALS->dump_file) return;
+
+    GwFacs *facs = gw_dump_file_get_facs(GLOBALS->dump_file);
+    if (!facs) return;
+
+    gint num_facs = gw_facs_get_length(facs);
+    if (num_facs == 0) return;
+
+    for (gint i = 0; i < num_facs; i++) {
+        GwSymbol *s = gw_facs_get(facs, i);
+        if(s && s->n) {
+            AddNode(s->n, NULL);
+        }
+    }
+
+    redraw_signals_and_waves();
+}
+
 char *GetFullName(GwTrace *t)
 {
     if (HasAlias(t) || !HasWave(t)) {

--- a/src/analyzer.h
+++ b/src/analyzer.h
@@ -215,6 +215,7 @@ void DisplayTraces(int val);
 int AddNodeTraceReturn(GwNode *nd, char *aliasname, GwTrace **tret);
 int AddNode(GwNode *nd, char *aliasname);
 int AddVector(GwBitVector *vec, char *aliasname);
+void analyzer_import_all_signals(void);
 int AddBlankTrace(char *commentname);
 int InsertBlankTrace(char *comment, TraceFlagsType different_flags);
 void RemoveNode(GwNode *n);

--- a/src/main.c
+++ b/src/main.c
@@ -71,12 +71,19 @@
 
 #include "tcl_helper.h"
 #include "vcd_partial_adapter.h"
+#include "analyzer.h"
 
 #ifdef MAC_INTEGRATION
 #include <gtkosxapplication.h>
 #endif
 
 char *gtkwave_argv0_cached = NULL;
+
+static gboolean add_all_signals_idle(gpointer user_data) {
+    (void)user_data;
+    analyzer_import_all_signals();
+    return G_SOURCE_REMOVE;
+}
 
 static void switch_page(GtkNotebook *notebook, gpointer *page, guint page_num, gpointer user_data)
 {
@@ -2024,6 +2031,10 @@ savefile_bail:
         wave_gconf_client_set_string("/current/savefile", GLOBALS->filesel_writesave);
     }
 #endif
+
+    if (is_interactive) {
+        g_idle_add(add_all_signals_idle, NULL);
+    }
 
     if (GLOBALS->dual_attach_id_main_c_1) {
         fprintf(stderr,

--- a/src/vcd_partial_adapter.c
+++ b/src/vcd_partial_adapter.c
@@ -121,7 +121,7 @@ static gboolean kick_timeout_callback(gpointer user_data)
             GwTrace *t = GLOBALS->traces.first;
             
             while (t && i < GLOBALS->traces.total) {
-                if (t->n.nd && t->n.nd->mv.mvlfac_vlist != NULL) {
+                if (t->n.nd && t->n.nd->mv.mvlfac_vlist_writer != NULL) {
                     nodes[i++] = t->n.nd;
                 }
                 t = t->t_next;


### PR DESCRIPTION
## Summary by Sourcery

Ensure interactive sessions automatically load and display all signals by adding an analyzer import function and handling partial VCD loads through a new flag and proper vlist_writer finalization.

New Features:
- Automatically import all signals on startup in interactive mode via an idle callback

Bug Fixes:
- Use `mvlfac_vlist_writer` instead of the finalized vlist to correctly detect and queue signals in kick_timeout_callback

Enhancements:
- Add a `partial_load` flag to GwVcdFile and finalize `mvlfac_vlist_writer` during partial VCD imports